### PR TITLE
Fix: ldap import refactor and fixes

### DIFF
--- a/Lagerregal/utils.py
+++ b/Lagerregal/utils.py
@@ -50,3 +50,22 @@ def get_file_location(instance=None, filename=""):
     destination += "{0}.{1}".format(uuid.uuid4(), ext)
 
     return destination
+
+
+def convert_ad_accountexpires(timestamp):
+    """
+    returns a datetime.date object
+    returns None when timestamp is 0, larger than date.max or on another error
+    """
+    if timestamp is None or timestamp == 0:
+        return None
+    epoch_start = date(year=1601, month=1,day=1)
+    seconds_since_epoch = timestamp/10**7
+    try:
+        # ad timestamp can be > than date.max, return None (==never expires)
+        new_date = epoch_start + timedelta(seconds=seconds_since_epoch)
+        return new_date
+    except OverflowError:
+        return None
+    except StandardError:
+        print('Cannot convert expiration_date "{0}", falling back to None'.format(self.expiration_date))

--- a/devices/management/commands/ldapimport.py
+++ b/devices/management/commands/ldapimport.py
@@ -63,6 +63,8 @@ class Command(BaseCommand):
         page_count, users = l.paged_search_ext_s(*settings.LDAP_USER_SEARCH)
 
         for dn, userdata in users:
+            if dn is not None:
+                dn = dn.decode('utf-8')
             saveuser = False
             created = False
             changes = {}
@@ -127,7 +129,7 @@ class Command(BaseCommand):
                     print("{0} does not have a value for the attribute {1}".format(dn, attr))
             if saveuser:
                 for field, (old_value, new_value) in changes.iteritems():
-                    print("{0} changed {1} from {2} to {3}".format(dn, field, old_value, new_value))
+                    print(u'{0} changed {1} from {2} to {3}'.format(dn, field, old_value, new_value))
                 user.save()
                 if user.main_department:
                     if not user.main_department in user.departments.all():

--- a/devices/management/commands/ldapimport.py
+++ b/devices/management/commands/ldapimport.py
@@ -3,10 +3,11 @@ import ldap
 from django.conf import settings  # import the settings file
 from django.core.management.base import BaseCommand
 import re
-from users.models import Lageruser, Department, DepartmentUser
+from users.models import Lageruser, Department, DepartmentUser, convert_ad_accountexpires
 from ldap.controls import SimplePagedResultsControl
 from ldap.ldapobject import LDAPObject
-from datetime import date
+from datetime import date, timedelta
+
 class PagedResultsSearchObject(LDAPObject):
   page_size = 50
 
@@ -48,83 +49,95 @@ class PagedResultsSearchObject(LDAPObject):
             break
     return result_pages,all_results
 
-
 class Command(BaseCommand):
     def handle(self, *args, **options):
-        if settings.USE_LDAP:
-            #ldap.set_option(ldap.OPT_DEBUG_LEVEL, 4095)
-            l = PagedResultsSearchObject(settings.AUTH_LDAP_SERVER_URI)
-            l.simple_bind_s(settings.AUTH_LDAP_BIND_DN, settings.AUTH_LDAP_BIND_PASSWORD)
-            created_users = 0
-            updated_users = 0
-            skipped_users = 0
-            page_count, users = l.paged_search_ext_s(*settings.LDAP_USER_SEARCH)
+        if not settings.USE_LDAP:
+            print("You have to enable the USE_LDAP setting to use the ldap import.")
+            return
+        #ldap.set_option(ldap.OPT_DEBUG_LEVEL, 4095)
+        l = PagedResultsSearchObject(settings.AUTH_LDAP_SERVER_URI)
+        l.simple_bind_s(settings.AUTH_LDAP_BIND_DN, settings.AUTH_LDAP_BIND_PASSWORD)
+        created_users = 0
+        updated_users = 0
+        skipped_users = 0
+        page_count, users = l.paged_search_ext_s(*settings.LDAP_USER_SEARCH)
 
-            for dn, userdata in users:
-                saveuser = False
-                created = False
+        for dn, userdata in users:
+            saveuser = False
+            created = False
+            changes = {}
+            try:
+                user = Lageruser.objects.get(username=userdata["sAMAccountName"][0])
+            except TypeError:
+                continue
+            except Exception as e:
+                saveuser = True
+                created = True
+                user = Lageruser(username=userdata["sAMAccountName"][0])
+            for field, attr in settings.AUTH_LDAP_USER_ATTR_MAP.iteritems():
                 try:
-                    user = Lageruser.objects.get(username=userdata["sAMAccountName"][0])
-                except TypeError:
-                    continue
-                except Exception as e:
-                    saveuser = True
-                    created = True
-                    user = Lageruser(username=userdata["sAMAccountName"][0])
-                for field, attr in settings.AUTH_LDAP_USER_ATTR_MAP.iteritems():
-                    try:
-                        new_value = userdata[attr][0].decode('unicode_escape').encode('iso8859-1').decode('utf8')
-                        if attr == settings.AUTH_LDAP_DEPARTMENT_FIELD:
+                    old_value = getattr(user, field)
+                    new_value = userdata[attr][0].decode('unicode_escape').encode('iso8859-1').decode('utf8')
+                    if attr == settings.AUTH_LDAP_DEPARTMENT_FIELD:
+                        try:
                             department_name = re.findall(settings.AUTH_LDAP_DEPARTMENT_REGEX, new_value)[-1]
-                            try:
-                                new_value = Department.objects.get(name=department_name)
-                            except Department.DoesNotExist as e:
-                                new_value = Department(name=department_name)
-                                new_value.save()
-                        elif attr == "accountExpires":
-                            if int(userdata["accountExpires"][0]) > 0:
-                                expires_timestamp = (int(userdata["accountExpires"][0])/10000000)-11644473600
-                                new_value = date.fromtimestamp(expires_timestamp)
-
-                                if created and new_value < date.today():
-                                    skipped_users += 1
-                                    saveuser = False
-                                    break
-
-                                if user.is_active != (new_value > date.today()):
-                                    user.is_active = new_value > date.today()
-                                    saveuser = True
-                        old_value = getattr(user, field)
-                        if old_value != new_value and (created or attr not in settings.AUTH_LDAP_ATTR_NOSYNC):
-                            saveuser = True
-                            setattr(user, field,new_value)
-                    except StandardError as e:
-                        if attr == "accountExpires":
-                            continue
-                        if attr == "givenName" or attr == "sn":
+                            new_value = Department.objects.get(name=department_name)
+                        except Department.DoesNotExist as e:
+                            new_value = Department(name=department_name)
+                            new_value.save()
+                        except IndexError:
                             skipped_users += 1
                             saveuser = False
                             break
-                        if attr == "sn":
-                            old_value = getattr(user, field)
-                            if old_value != userdata["sAMAccountName"][0]:
-                                saveuser = True
-                                setattr(user, field, userdata["sAMAccountName"][0])
-                                continue
-                        print("{0} does not have a value for the attribute {1}".format(dn, attr))
-                if saveuser:
-                    user.save()
-                    if user.main_department:
-                        if not user.main_department in user.departments.all():
-                            department_user = DepartmentUser(user=user, department=user.main_department, role="m")
-                            department_user.save()
-                    if created:
-                        created_users += 1
-                    else:
-                        updated_users += 1
+                    elif attr == "accountExpires":
+                        expired = False
+                        if userdata['accountExpires'][0] == '0':
+                            new_value = None
+                        else:
+                            new_value = convert_ad_accountexpires(int(userdata['accountExpires'][0]))
+                            if new_value is not None:
+                                expired = new_value < date.today()
 
-            print("skipped {0} users.".format(skipped_users))
-            print("imported {0} new users.".format(created_users))
-            print("updated {0} exisitng users.".format(updated_users))
-        else:
-            print("You have to enable the USE_LDAP setting to use the ldap import.")
+                        if created and expired:
+                            skipped_users += 1
+                            saveuser = False
+                            break
+
+                        if user.is_active == expired:
+                            user.is_active = not expired
+                            saveuser = True
+                            print("{0} has expired".format(dn))
+                    if old_value != new_value and (created or attr not in settings.AUTH_LDAP_ATTR_NOSYNC):
+                        saveuser = True
+                        setattr(user, field, new_value)
+                        changes[field] = (old_value, new_value)
+                except StandardError as e:
+                    if attr == "accountExpires":
+                        continue
+                    if attr == "givenName" or attr == "sn":
+                        skipped_users += 1
+                        saveuser = False
+                        break
+                    if attr == "sn":
+                        old_value = getattr(user, field)
+                        if old_value != userdata["sAMAccountName"][0]:
+                            saveuser = True
+                            setattr(user, field, userdata["sAMAccountName"][0])
+                            continue
+                    print("{0} does not have a value for the attribute {1}".format(dn, attr))
+            if saveuser:
+                for field, (old_value, new_value) in changes.iteritems():
+                    print("{0} changed {1} from {2} to {3}".format(dn, field, old_value, new_value))
+                user.save()
+                if user.main_department:
+                    if not user.main_department in user.departments.all():
+                        department_user = DepartmentUser(user=user, department=user.main_department, role="m")
+                        department_user.save()
+                if created:
+                    created_users += 1
+                else:
+                    updated_users += 1
+
+        print("skipped {0} users.".format(skipped_users))
+        print("imported {0} new users.".format(created_users))
+        print("updated {0} exisitng users.".format(updated_users))

--- a/devices/management/commands/ldapimport.py
+++ b/devices/management/commands/ldapimport.py
@@ -3,10 +3,11 @@ import ldap
 from django.conf import settings  # import the settings file
 from django.core.management.base import BaseCommand
 import re
-from users.models import Lageruser, Department, DepartmentUser, convert_ad_accountexpires
+from users.models import Lageruser, Department, DepartmentUser
 from ldap.controls import SimplePagedResultsControl
 from ldap.ldapobject import LDAPObject
 from datetime import date, timedelta
+from Lagerregal import utils
 
 class PagedResultsSearchObject(LDAPObject):
   page_size = 50
@@ -96,7 +97,7 @@ class Command(BaseCommand):
                         if userdata['accountExpires'][0] == '0':
                             new_value = None
                         else:
-                            new_value = convert_ad_accountexpires(int(userdata['accountExpires'][0]))
+                            new_value = utils.convert_ad_accountexpires(int(userdata['accountExpires'][0]))
                             if new_value is not None:
                                 expired = new_value < date.today()
 

--- a/users/models.py
+++ b/users/models.py
@@ -14,24 +14,6 @@ from datetime import date, timedelta
 from Lagerregal import utils
 import logging
 
-def convert_ad_accountexpires(timestamp):
-    """
-    returns a datetime.date object
-    returns None when timestamp is 0, larger than date.max or on another error
-    """
-    if timestamp is None or timestamp == 0:
-        return None
-    epoch_start = date(year=1601, month=1,day=1)
-    seconds_since_epoch = timestamp/10**7
-    try:
-        # ad timestamp can be > than date.max, return None (==never expires)
-        new_date = epoch_start + timedelta(seconds=seconds_since_epoch)
-        return new_date
-    except OverflowError:
-        return None
-    except StandardError:
-        print('Cannot convert expiration_date "{0}", falling back to None'.format(self.expiration_date))
-
 class Lageruser(AbstractUser):
     language = models.CharField(max_length=10, null=True, blank=True,
                                 choices=settings.LANGUAGES, default=settings.LANGUAGES[0][0])
@@ -107,7 +89,7 @@ def populate_ldap_user(sender, signal, user, ldap_user, **kwargs):
                 user.main_department = department
 
     if "accountExpires" in ldap_user.attrs:
-        expiration_date = convert_ad_accountexpires(int(ldap_user.attrs['accountExpires'][0]))
+        expiration_date = utils.convert_ad_accountexpires(int(ldap_user.attrs['accountExpires'][0]))
         user.expiration_date = expiration_date
 
         if user.expiration_date and user.expiration_date < date.today():

--- a/users/models.py
+++ b/users/models.py
@@ -84,9 +84,10 @@ def populate_ldap_user(sender, signal, user, ldap_user, **kwargs):
 
     see: https://pythonhosted.org/django-auth-ldap/users.html
     """
-    logger = logging.getLogger('django_auth_ldap')
-    logger.addHandler(logging.StreamHandler())
-    logger.setLevel(logging.DEBUG)
+    if settings.DEBUG:
+        logger = logging.getLogger('django_auth_ldap')
+        logger.addHandler(logging.StreamHandler())
+        logger.setLevel(logging.DEBUG)
     AUTH_LDAP_DEPARTMENT_REGEX = getattr(settings, "AUTH_LDAP_DEPARTMENT_REGEX", None)
     if AUTH_LDAP_DEPARTMENT_REGEX != None and user.main_department == None:
         AUTH_LDAP_DEPARTMENT_FIELD = getattr(settings, "AUTH_LDAP_DEPARTMENT_REGEX", None)

--- a/users/models.py
+++ b/users/models.py
@@ -10,8 +10,27 @@ from django.dispatch import receiver
 from django_auth_ldap.backend import populate_user
 from django.conf import settings
 import re
-import datetime
+from datetime import date, timedelta
 from Lagerregal import utils
+import logging
+
+def convert_ad_accountexpires(timestamp):
+    """
+    returns a datetime.date object
+    returns None when timestamp is 0, larger than date.max or on another error
+    """
+    if timestamp is None or timestamp == 0:
+        return None
+    epoch_start = date(year=1601, month=1,day=1)
+    seconds_since_epoch = timestamp/10**7
+    try:
+        # ad timestamp can be > than date.max, return None (==never expires)
+        new_date = epoch_start + timedelta(seconds=seconds_since_epoch)
+        return new_date
+    except OverflowError:
+        return None
+    except StandardError:
+        print('Cannot convert expiration_date "{0}", falling back to None'.format(self.expiration_date))
 
 class Lageruser(AbstractUser):
     language = models.CharField(max_length=10, null=True, blank=True,
@@ -46,6 +65,11 @@ class Lageruser(AbstractUser):
     def get_absolute_url(self):
         return reverse('userprofile', kwargs={'pk': self.pk})
 
+    def clean(self):
+        # initial ldap population returns a positive int as string
+        # will be set correctly later by populate_ldap_user() / ldapimport cmd
+        self.expiration_date = None
+
     @staticmethod
     def users_from_departments(departments=[]):
         if len(departments) == 0:
@@ -55,6 +79,14 @@ class Lageruser(AbstractUser):
 
 @receiver(populate_user)
 def populate_ldap_user(sender, signal, user, ldap_user, **kwargs):
+    """
+    this signal is sent after the user object has been created, to override/add specific fields
+
+    see: https://pythonhosted.org/django-auth-ldap/users.html
+    """
+    logger = logging.getLogger('django_auth_ldap')
+    logger.addHandler(logging.StreamHandler())
+    logger.setLevel(logging.DEBUG)
     AUTH_LDAP_DEPARTMENT_REGEX = getattr(settings, "AUTH_LDAP_DEPARTMENT_REGEX", None)
     if AUTH_LDAP_DEPARTMENT_REGEX != None and user.main_department == None:
         AUTH_LDAP_DEPARTMENT_FIELD = getattr(settings, "AUTH_LDAP_DEPARTMENT_REGEX", None)
@@ -74,17 +106,12 @@ def populate_ldap_user(sender, signal, user, ldap_user, **kwargs):
                 user.main_department = department
 
     if "accountExpires" in ldap_user.attrs:
-        if int(ldap_user.attrs["accountExpires"][0]) > 0:
-            expires_timestamp = (int(ldap_user.attrs["accountExpires"][0])/10000000)-11644473600
-            try:
-                expires_date = datetime.date.fromtimestamp(expires_timestamp)
-            except StandardError:
-                expires_date = None
-            user.expiration_date = expires_date
+        expiration_date = convert_ad_accountexpires(int(ldap_user.attrs['accountExpires'][0]))
+        user.expiration_date = expiration_date
 
-            if user.expiration_date:
-                if user.expiration_date < datetime.date.today():
-                    user.is_active = False
+        if user.expiration_date and user.expiration_date < date.today():
+            user.is_active = False
+
     user.save()
 
 


### PR DESCRIPTION
+ enable and clean up expiration date import a little
+ when accountExpires in AUTH_LDAP_USER_ATTR_MAP we need to clean() the field
before it gets passed to populate_user() handler
+ use convert_ad_accountexpires() where necessary