### PR TITLE
Add django-favicon for favicon corner case

### DIFF
--- a/Lagerregal/settings_template.py
+++ b/Lagerregal/settings_template.py
@@ -290,3 +290,5 @@ THEMES = [
     'united',
     'paper',
 ]
+
+FAVICON_PATH = STATIC_URL + 'images/favicon.ico'

--- a/Lagerregal/urls.py
+++ b/Lagerregal/urls.py
@@ -216,6 +216,8 @@ urlpatterns = [
 
     url(r'^oauth2/', include('oauth2_provider.urls', namespace='oauth2_provider')),
 
+    url(r'^', include('favicon.urls')),
+
     url(r'^ajax/add_widget', login_required(WidgetAdd.as_view()), name="widget_add"),
     url(r'^ajax/remove_widget', login_required(WidgetRemove.as_view()), name="widget_remove"),
     url(r'^ajax/toggle_widget', login_required(WidgetToggle.as_view()), name="widget_toggle"),

--- a/dependencies.txt
+++ b/dependencies.txt
@@ -10,3 +10,4 @@ model_mommy
 django-casper
 django-permission
 django_auth_ldap
+django-favicon


### PR DESCRIPTION
In certain cases Browsers may request `^/favicon.ico$` (at least Firefox) from our app.
And there is an app for that.