### PR TITLE
Widget related fixes

### DIFF
--- a/main/views.py
+++ b/main/views.py
@@ -18,6 +18,8 @@ from devices.forms import LendForm
 def get_widget_data(user, widgetlist=[], departments=None):
     context = {}
     context["today"] = datetime.date.today()
+    if departments is None:
+        departments = []
     if "statistics" in widgetlist:
         if departments:
             devices = Device.active().filter(department__in=departments)

--- a/templates/snippets/modals/addwidget.html
+++ b/templates/snippets/modals/addwidget.html
@@ -6,7 +6,7 @@
 
 {% block modalBody %}
     <ul style="list-style-type: none;" id="widgetlist">
-        {% for widgetname, widgetvalue in widgets_list.iteritems %}
+        {% for widgetname, widgetvalue in widgets_list.items %}
             <li><a data-name="{{ widgetname }}" class="addWidget">{{ widgetvalue }}</a></li>
         {% endfor %}
     </ul>


### PR DESCRIPTION
While checking out what has changed in the past months, I noticed that it was not possible to add widgets anymore, because the modal was always empty. This is because `iteritems` doesn't exist in python3 anymore.
I also ran into an issue trying to view the edit history widget while not being in a department. While this is not a usecase that should happen at the MPIB, I fixed it anyway.