### PR TITLE
added try except with 404 error

### DIFF
--- a/devices/views.py
+++ b/devices/views.py
@@ -223,8 +223,10 @@ class DeviceDetail(DetailView):
 
         pk = self.kwargs.get(self.pk_url_kwarg)
         queryset = self.queryset.filter(pk=pk)
-        self.object = queryset.get()
-
+        try:
+            self.object = queryset.get()
+        except Device.DoesNotExist:
+            raise Http404
         return self.object
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
When using "jump to id", when the device is not found, a 500 error is thrown. Changed this to 404 to avoid confusion on the user side and error mails being sent