### PR TITLE
handle language activation in middleware

### DIFF
--- a/Lagerregal/base_settings.py
+++ b/Lagerregal/base_settings.py
@@ -63,7 +63,8 @@ MIDDLEWARE = (
     # Uncomment the next line for simple clickjacking protection:
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'debug_toolbar.middleware.DebugToolbarMiddleware',
-    'users.middleware.TimezoneMiddleware'
+    'users.middleware.TimezoneMiddleware',
+    'users.middleware.LanguageMiddleware',
 )
 
 ROOT_URLCONF = 'Lagerregal.urls'

--- a/users/middleware.py
+++ b/users/middleware.py
@@ -1,4 +1,5 @@
 from django.utils import timezone
+from django.utils import translation
 
 
 class TimezoneMiddleware:
@@ -10,4 +11,16 @@ class TimezoneMiddleware:
         if user.is_authenticated:
             if user.timezone is not None:
                 timezone.activate(user.timezone)
+        return self.get_response(request)
+
+
+class LanguageMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        user = request.user
+        if user.is_authenticated:
+            if user.language is not None:
+                translation.activate(user.language)
         return self.get_response(request)

--- a/users/views.py
+++ b/users/views.py
@@ -2,7 +2,6 @@ from django.views.generic import DetailView, TemplateView, ListView, CreateView,
 from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
-from django.utils import translation
 from django.contrib import messages
 from django.contrib.contenttypes.models import ContentType
 from django.shortcuts import render
@@ -172,8 +171,6 @@ class UsersettingsView(TemplateView):
         if "language" in request.POST:
             request.user.language = request.POST["language"]
             request.user.save()
-            translation.activate(request.POST["language"])
-            request.session[translation.LANGUAGE_SESSION_KEY] = request.POST["language"]
             return HttpResponseRedirect(reverse("usersettings"))
 
         # handle pagelength/ timezone/ theme settings and use saved settings of user as default


### PR DESCRIPTION
In #292 we accidentally stopped using our own login view which was removed completely in #295. The only thing special about it was that it handled language activation. To restore that to a functional state I added a `LanguageMiddleware` which is extremely similar to both the existing `TimezoneMiddleware` and the `UserLanguageMiddleware` that is used in castellum, another MPIB project.