### PR TITLE
avoid passing redundant information in form

### DIFF
--- a/devices/forms.py
+++ b/devices/forms.py
@@ -103,7 +103,6 @@ class IpAddressForm(forms.Form):
     ipaddresses = forms.ModelMultipleChoiceField(
         IpAddress.objects.filter(device=None, user=None),
         widget=Select2MultipleWidget(attrs={"style": "width:100%;", "data-token-separators": '[",", " "]'}))
-    device = forms.ModelChoiceField(Device.objects.all())
 
 
 class IpAddressPurposeForm(forms.Form):

--- a/devices/tests.py
+++ b/devices/tests.py
@@ -162,7 +162,6 @@ class DeviceTests(TestCase):
         device.refresh_from_db()
         self.assertEqual(device.bookmarkers.count(), 0)
 
-    @unittest.skip('failing')
     def test_ipaddress_view(self):
         device = mommy.make(Device)
         ip = mommy.make(IpAddress)

--- a/devicetags/forms.py
+++ b/devicetags/forms.py
@@ -3,7 +3,6 @@ from django import forms
 from django_select2.forms import Select2MultipleWidget
 
 from devicetags.models import Devicetag
-from devices.models import Device
 
 
 class TagForm(forms.ModelForm):
@@ -17,4 +16,3 @@ class DeviceTagForm(forms.Form):
     tags = forms.ModelMultipleChoiceField(
         Devicetag.objects.all(),
         widget=Select2MultipleWidget(attrs={"style": "width:100%;", "data-token-separators": '[",", " "]'}))
-    device = forms.ModelChoiceField(Device.objects.all())

--- a/devicetags/tests.py
+++ b/devicetags/tests.py
@@ -1,5 +1,3 @@
-import unittest
-
 from django.test.client import Client
 from django.test import TestCase
 from django.urls import reverse
@@ -42,7 +40,6 @@ class DevicetagsTests(TestCase):
         response = self.client.get('/devicetags/delete/%i' % tag.pk)
         self.assertEqual(response.status_code, 200)
 
-    @unittest.skip('failing')
     def test_devicetags_view(self):
         device = mommy.make(Device)
         tag = mommy.make(Devicetag)

--- a/devicetags/views.py
+++ b/devicetags/views.py
@@ -115,24 +115,26 @@ class DeviceTags(FormView):
     form_class = DeviceTagForm
     success_url = "/devices"
 
+    def dispatch(self, request, **kwargs):
+        self.object = get_object_or_404(Device, pk=self.kwargs['pk'])
+        return super().dispatch(request, **kwargs)
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        device = context["form"].cleaned_data["device"]
 
         # adds "Devices" to breadcrumbs
         context["breadcrumbs"] = [
             (reverse("device-list"), _("Devices")),
-            (reverse("device-detail", kwargs={"pk": device.pk}), device.name),
+            (reverse("device-detail", kwargs={"pk": self.object.pk}), self.object.name),
             ("", _("Assign Tags"))]
 
         return context
 
     def form_valid(self, form):
         tags = form.cleaned_data["tags"]
-        device = form.cleaned_data["device"]
-        device.tags.add(*tags)
+        self.object.tags.add(*tags)
 
-        return HttpResponseRedirect(reverse("device-detail", kwargs={"pk": device.pk}))
+        return HttpResponseRedirect(reverse("device-detail", kwargs={"pk": self.object.pk}))
 
 
 class DeviceTagRemove(PermissionRequiredMixin, DeleteView):

--- a/network/forms.py
+++ b/network/forms.py
@@ -4,7 +4,6 @@ from django.utils.translation import ugettext_lazy as _
 from django_select2.forms import Select2MultipleWidget
 
 from network.models import IpAddress
-from users.models import Lageruser
 from devices.forms import get_department_options
 
 VIEWFILTER = (
@@ -42,4 +41,3 @@ class UserIpAddressForm(forms.Form):
     ipaddresses = forms.ModelMultipleChoiceField(
         IpAddress.objects.filter(device=None, user=None),
         widget=Select2MultipleWidget(attrs={"style": "width:100%;", "data-token-separators": '[",", " "]'}))
-    user = forms.ModelChoiceField(Lageruser.objects.all())

--- a/network/tests.py
+++ b/network/tests.py
@@ -56,7 +56,6 @@ class IpAddressTests(TestCase):
         response = self.client.get('/ipaddresses/delete/%i' % address.pk)
         self.assertEqual(response.status_code, 200)
 
-    @unittest.skip('failing')
     def test_user_view(self):
         response = self.client.get('/users/view/%i/ipaddress/' % self.admin.pk)
         self.assertEqual(response.status_code, 200)

--- a/templates/devices/device_detail.html
+++ b/templates/devices/device_detail.html
@@ -361,7 +361,6 @@
                                         id="submitipaddress"><i class="fa fa-plus"></i> {% trans "Assign Addresses" %}
                                 </button>
                             </div>
-                            <input type="hidden" name="device" value="{{ device.pk }}"/>
                         </form>
                     </div>
                 {% endif %}
@@ -385,7 +384,6 @@
                             <button type="submit" class="btn btn-success btn-sm pull-right disabled" id="submittags"><i
                                     class="fa fa-plus"></i> {% trans "Assign Tags" %}</button>
                         </div>
-                        <input type="hidden" name="device" value="{{ device.pk }}"/>
                     </form>
                 </div>
             </div>

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -215,7 +215,6 @@
                                     id="submitipaddress"><i class="fa fa-plus"></i> {% trans "Assign Addresses" %}
                             </button>
                         </div>
-                        <input type="hidden" name="user" value="{{ profileuser.pk }}"/>
                     </form>
                 </div>
             {% endif %}


### PR DESCRIPTION
These views are usually used with POST. This fixes the GET case.